### PR TITLE
Restore `__init__.py`, which was deleted in 0a23fa4. Fixes #2

### DIFF
--- a/src/geldaq/__init__.py
+++ b/src/geldaq/__init__.py
@@ -1,0 +1,6 @@
+"""Short description of your project.
+
+Long description of your project.
+"""
+
+__version__ = "0.0.0"


### PR DESCRIPTION
The purpose of this file (which needs to exist in `src/geldaq`) is to identify this folder as package, to provide metadata (such as the package version), and also to set up the package whenever it is first imported by calling code. This was deleted in 0a23fa4, so I am restoring it.

Fixes #2, "Deletion of `__init__.py` broke the package"